### PR TITLE
Update link for Google Fonts to use HTTPS protocol

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -9,7 +9,7 @@ CMSSettingsController:
 
 LeftAndMain:
   extra_requirements_css:
-    - http://fonts.googleapis.com/css?family=Open+Sans:400,700,400italic,700italic,300italic,300,600,600italic
+    - https://fonts.googleapis.com/css?family=Open+Sans:400,700,400italic,700italic,300italic,300,600,600italic
     - https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css
     - silverstripe-branding/css/main.css
   extensions:


### PR DESCRIPTION
Very minor, fix browser complaining about loading possible external 'unsafe' script if site domain is set for HTTPS, I noticed Chrome does this (even thoughts its a CSS file), but I guess the origin of the Font file (.woff2) in the actual CSS file, it doesn't like.