### PR TITLE
Update cms-sitename__title to include CMSVersion

### DIFF
--- a/templates/SilverStripe/Admin/Includes/LeftAndMain_MenuLogo.ss
+++ b/templates/SilverStripe/Admin/Includes/LeftAndMain_MenuLogo.ss
@@ -1,7 +1,7 @@
 <div class="cms-sitename">
   <% if $SiteConfig.CustomCMSLogo %>
     <div class="logo">
-      <a href="{$BaseHref}" target="_blank" class="cms-logo">
+      <a href="{$BaseHref}" target="_blank" class="cms-logo" title="$ApplicationName (Version - $CMSVersion)">
         <% if $SiteConfig.CustomCMSLogo.ID %>
           {$SiteConfig.CustomCMSLogo}
         <% else %>
@@ -10,7 +10,7 @@
       </a>
     </div>
   <% else %>
-    <a class="cms-sitename__title" href="$BaseHref" target="_blank">
+    <a class="cms-sitename__title" href="$BaseHref" target="_blank" title="$ApplicationName (Version - $CMSVersion)">
       <% if $SiteConfig %>$SiteConfig.Title<% else %>$ApplicationName<% end_if %>
     </a>
   <% end_if %>


### PR DESCRIPTION
First of all, I love your work! I'm using your theme as a replacement for CMS Grouped Menus to reduce the amount of "clutter" in my ModelAdmin column and it works beautifully  :)

When a user or developer is debugging a SilverStripe application, the most common way to identify the version is to log into the CMS and move the mouse over the SilverStripe logo. This is missing in your themed version, so I've ported that feature over from the main CMS project.

Keep up the great work!